### PR TITLE
Fix error mysql not running properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Alex Comunian <alex.comunian@gmail.com>
 RUN dpkg-divert --local --rename --add /sbin/initctl
 RUN ln -sf /bin/true /sbin/initctl
 RUN mkdir /var/run/sshd
+RUN mkdir /var/run/mysqld
 RUN mkdir /run/php
 
 # Let the conatiner know that there is no tty
@@ -22,6 +23,7 @@ RUN apt-get -y install php-xml php-mbstring php-bcmath php-zip php-pdo-mysql php
 
 # mysql config
 RUN sed -i -e"s/^bind-address\s*=\s*127.0.0.1/explicit_defaults_for_timestamp = true\nbind-address = 0.0.0.0/" /etc/mysql/mysql.conf.d/mysqld.cnf
+RUN chown mysql:mysql /var/run/mysqld
 
 # nginx config
 RUN sed -i -e"s/user\s*www-data;/user topix www-data;/" /etc/nginx/nginx.conf
@@ -71,7 +73,7 @@ EXPOSE 80
 EXPOSE 22
 
 # volume for mysql database and install
-VOLUME ["/var/lib/mysql", "/usr/share/nginx/www", "/var/run/sshd"]
+VOLUME ["/var/lib/mysql", "/usr/share/nginx/www", "/var/run/sshd", "/var/run/mysqld"]
 
 # Run
 CMD ["/bin/bash", "/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update
 RUN apt-get -y upgrade
 
 # Basic Requirements
-RUN apt-get -y install pwgen python-setuptools curl git nano sudo unzip openssh-server openssl vim htop
+RUN apt-get -y install pwgen python-setuptools python-pip curl git nano sudo unzip openssh-server openssl vim htop
 RUN apt-get -y install mysql-server mysql-client nginx php-fpm php-mysql
 
 # PHP Requirements
@@ -43,8 +43,10 @@ RUN sed -i -e "s/user\s*=\s*www-data/user = topix/g" /etc/php/7.0/fpm/pool.d/www
 ADD ./nginx-site.conf /etc/nginx/sites-available/default
 
 # Supervisor Config
-RUN /usr/bin/easy_install supervisor
-RUN /usr/bin/easy_install supervisor-stdout
+#RUN /usr/bin/easy_install supervisor
+#RUN /usr/bin/easy_install supervisor-stdout
+RUN python -m pip install supervisor
+RUN python -m pip install supervisor-stdout
 ADD ./supervisord.conf /etc/supervisord.conf
 
 # Add system user for topix


### PR DESCRIPTION
Hi, I'm trying to run this container and get that mysql is not running properly.

found the following error:
```
topix@2cdbed108f4b:~$ sudo tail -n 50 /var/log/mysql/error.log
2022-04-26T03:23:02.043684Z 0 [Note] Server hostname (bind-address): '0.0.0.0'; port: 3306
2022-04-26T03:23:02.043717Z 0 [Note]   - '0.0.0.0' resolves to '0.0.0.0';
2022-04-26T03:23:02.043803Z 0 [Note] Server socket created on IP: '0.0.0.0'.
2022-04-26T03:23:02.043900Z 0 [ERROR] Could not create unix socket lock file /var/run/mysqld/mysqld.sock.lock.
2022-04-26T03:23:02.043935Z 0 [ERROR] Unable to setup unix socket lock file.
2022-04-26T03:23:02.043962Z 0 [ERROR] Aborting

2022-04-26T03:23:02.043995Z 0 [Note] Binlog end
2022-04-26T03:23:02.044111Z 0 [Note] Shutting down plugin 'ngram'
2022-04-26T03:23:02.044138Z 0 [Note] Shutting down plugin 'ARCHIVE'
2022-04-26T03:23:02.044154Z 0 [Note] Shutting down plugin 'BLACKHOLE'
2022-04-26T03:23:02.044170Z 0 [Note] Shutting down plugin 'partition'
2022-04-26T03:23:02.044185Z 0 [Note] Shutting down plugin 'CSV'
```

Then, I tried to add a little command to the Dockerfile like this:
```
...
RUN mkdir /var/run/sshd
RUN mkdir /var/run/mysqld
...
# mysql config
...
RUN chown mysql:mysql /var/run/mysqld
...
# volume for mysql database and install
VOLUME ["/var/lib/mysql", "/usr/share/nginx/www", "/var/run/sshd", "/var/run/mysqld"]
```

And everything went good.